### PR TITLE
Updated the repo in response to the 2-field impl. of mm_array_ptr.

### DIFF
--- a/benchmarks/checked/parson/parson.c
+++ b/benchmarks/checked/parson/parson.c
@@ -1579,7 +1579,7 @@ mm_ptr<JSON_Value> json_value_deep_copy(mm_ptr<const JSON_Value> value) {
 
 size_t json_serialization_size(mm_ptr<const JSON_Value> value) {
     /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
-    _multiple char num_buf[NUM_BUF_SIZE];
+    _checkable char num_buf[NUM_BUF_SIZE];
     int res = json_serialize_to_buffer_r(value, NULL, 0, 0, num_buf);
     return res < 0 ? 0 : (size_t)(res) + 1;
 }
@@ -1641,7 +1641,7 @@ mm_array_ptr<char> json_serialize_to_string(mm_ptr<const JSON_Value> value) {
 
 size_t json_serialization_size_pretty(mm_ptr<const JSON_Value> value) {
     /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
-    _multiple char num_buf[NUM_BUF_SIZE];
+    _checkable char num_buf[NUM_BUF_SIZE];
     int res = json_serialize_to_buffer_r(value, NULL, 0, 1, num_buf);
     return res < 0 ? 0 : (size_t)(res) + 1;
 }

--- a/benchmarks/checked/parson/tests.c
+++ b/benchmarks/checked/parson/tests.c
@@ -649,7 +649,7 @@ void print_commits_info(const char *username, const char *repo) {
 void persistence_example(void) {
     mm_ptr<JSON_Value> schema = json_parse_string("{\"name\":\"\"}");
     mm_ptr<JSON_Value> user_data = json_parse_file(get_file_path("user_data.json"));
-    _multiple char buf[256];
+    _checkable char buf[256];
     mm_array_ptr<const char> name = NULL;
     if (user_data == NULL || json_validate(schema, user_data) != JSONSuccess) {
         puts("Enter your name:");

--- a/benchmarks/checked/thttpd-2.29/libhttpd.c
+++ b/benchmarks/checked/thttpd-2.29/libhttpd.c
@@ -624,7 +624,7 @@ send_mime( mm_ptr<httpd_conn> hc, int status, char* title, char* encodings,
     char modbuf[100];
     char expbuf[100];
     char fixed_type[500];
-    _multiple char buf[1000];
+    _checkable char buf[1000];
     int partial_content;
     int s100;
 
@@ -707,7 +707,7 @@ send_mime( mm_ptr<httpd_conn> hc, int status, char* title, char* encodings,
 	    }
 	if ( extraheads[0] != '\0' )
 	    add_response( hc, extraheads );
-    _multiple char tmpstr[10] = "\015\012";
+    _checkable char tmpstr[10] = "\015\012";
 	add_response( hc, tmpstr);
 	}
     }
@@ -779,7 +779,7 @@ send_response(mm_ptr<httpd_conn> hc, int status, char* title,
         mm_array_ptr<char> extraheads, char* form, char* arg )
     {
     char defanged_arg[1000];
-    _multiple char buf[2000];
+    _checkable char buf[2000];
 
     send_mime(
 	hc, status, title, "", extraheads, "text/html; charset=%s", (off_t) -1,
@@ -817,7 +817,7 @@ send_response(mm_ptr<httpd_conn> hc, int status, char* title,
 static void
 send_response_tail( mm_ptr<httpd_conn> hc )
     {
-    _multiple char buf[1000];
+    _checkable char buf[1000];
 
     (void) my_snprintf((char *)buf, sizeof(buf), "\
     <hr>\n\
@@ -904,7 +904,7 @@ static int
 send_err_file( mm_ptr<httpd_conn> hc, int status, char* title, mm_array_ptr<char> extraheads, char* filename )
     {
     FILE* fp;
-    _multiple char buf[1000];
+    _checkable char buf[1000];
     size_t r;
 
     fp = fopen( filename, "r" );
@@ -936,8 +936,8 @@ send_err_file( mm_ptr<httpd_conn> hc, int status, char* title, mm_array_ptr<char
 
 static void
 send_authenticate( mm_ptr<httpd_conn> hc, char* realm ) {
-    _multiple static mm_array_ptr<char> header = NULL;
-    _multiple static size_t maxheader = 0;
+    _checkable static mm_array_ptr<char> header = NULL;
+    _checkable static size_t maxheader = 0;
     static char headstr[] = "WWW-Authenticate: Basic realm=\"";
 
     mm_httpd_realloc_str(
@@ -1063,8 +1063,8 @@ static int
 auth_check2( mm_ptr<httpd_conn> hc, char* dirname  )
     {
         int i = 20;
-    static _multiple mm_array_ptr<char> authpath = NULL;
-    static _multiple size_t maxauthpath = 0;
+    static _checkable mm_array_ptr<char> authpath = NULL;
+    static _checkable size_t maxauthpath = 0;
     struct stat sb;
     char authinfo[500];
     char* authpass;
@@ -1073,13 +1073,13 @@ auth_check2( mm_ptr<httpd_conn> hc, char* dirname  )
     FILE* fp;
     char line[500];
     char* cryp;
-    static _multiple mm_array_ptr<char> prevauthpath = NULL;
-    static _multiple size_t maxprevauthpath = 0;
+    static _checkable mm_array_ptr<char> prevauthpath = NULL;
+    static _checkable size_t maxprevauthpath = 0;
     static time_t prevmtime;
-    static _multiple mm_array_ptr<char> prevuser = NULL;
-    static _multiple size_t maxprevuser = 0;
-    static _multiple mm_array_ptr<char> prevcryp = NULL;
-    static _multiple size_t maxprevcryp = 0;
+    static _checkable mm_array_ptr<char> prevuser = NULL;
+    static _checkable size_t maxprevuser = 0;
+    static _checkable mm_array_ptr<char> prevcryp = NULL;
+    static _checkable size_t maxprevcryp = 0;
 
     /* Construct auth filename. */
     mm_httpd_realloc_str(
@@ -1213,10 +1213,10 @@ auth_check2( mm_ptr<httpd_conn> hc, char* dirname  )
 static void
 send_dirredirect( mm_ptr<httpd_conn> hc )
     {
-    static _multiple mm_array_ptr<char> location = NULL;
-    static _multiple mm_array_ptr<char> header = NULL;
-    static _multiple size_t maxlocation = 0;
-    static _multiple size_t maxheader = 0;
+    static _checkable mm_array_ptr<char> location = NULL;
+    static _checkable mm_array_ptr<char> header = NULL;
+    static _checkable size_t maxlocation = 0;
+    static _checkable size_t maxheader = 0;
     static char headstr[] = "Location: ";
 
     if ( hc->query[0] != '\0')
@@ -1327,8 +1327,8 @@ strencode( char* to, int tosize, char* from )
 static int
 tilde_map_1( httpd_conn* hc )
     {
-    static _multiple mm_array_ptr<char> temp = NULL;
-    static _multiple size_t maxtemp = 0;
+    static _checkable mm_array_ptr<char> temp = NULL;
+    static _checkable size_t maxtemp = 0;
     int len;
     static char* prefix = TILDE_MAP_1;
 
@@ -1349,8 +1349,8 @@ tilde_map_1( httpd_conn* hc )
 static int
 tilde_map_2( httpd_conn* hc )
     {
-    static _multiple mm_array_ptr<char> temp = NULL;
-    static _multiple size_t maxtemp = 0;
+    static _checkable mm_array_ptr<char> temp = NULL;
+    static _checkable size_t maxtemp = 0;
     static char* postfix = TILDE_MAP_2;
     char* cp;
     struct passwd* pw;
@@ -1406,8 +1406,8 @@ vhost_map( mm_ptr<httpd_conn> hc )
     {
     httpd_sockaddr sa;
     socklen_t sz;
-    static _multiple mm_array_ptr<char> tempfilename = NULL;
-    static _multiple size_t maxtempfilename = 0;
+    static _checkable mm_array_ptr<char> tempfilename = NULL;
+    static _checkable size_t maxtempfilename = 0;
     char* cp1;
     int len;
 #ifdef VHOST_DIRLEVELS
@@ -1496,10 +1496,10 @@ vhost_map( mm_ptr<httpd_conn> hc )
 static mm_array_ptr<char>
 expand_symlinks( char* path, mm_ptr<mm_array_ptr<char>> restP, int no_symlink_check, int tildemapped )
     {
-    static _multiple mm_array_ptr<char> checked = NULL;
-    static _multiple mm_array_ptr<char> rest = NULL;
+    static _checkable mm_array_ptr<char> checked = NULL;
+    static _checkable mm_array_ptr<char> rest = NULL;
     char lnk[5000];
-    static _multiple size_t maxchecked = 0, maxrest = 0;
+    static _checkable size_t maxchecked = 0, maxrest = 0;
     size_t checkedlen, restlen, linklen, prevcheckedlen, prevrestlen;
     int nlinks, i;
     mm_array_ptr<char> r = NULL;
@@ -1999,7 +1999,7 @@ httpd_parse_request( mm_ptr<httpd_conn> hc )
     char* reqhost;
     char* eol;
     char* cp;
-    _multiple mm_array_ptr<char> pi = NULL;
+    _checkable mm_array_ptr<char> pi = NULL;
 
     hc->checked_idx = 0;	/* reset */
     method_str = bufgets( hc );
@@ -3048,8 +3048,8 @@ build_env( char* fmt, char* arg )
     {
     char* cp;
     size_t size;
-    static _multiple mm_array_ptr<char> buf = NULL;
-    static _multiple size_t maxbuf = 0;
+    static _checkable mm_array_ptr<char> buf = NULL;
+    static _checkable size_t maxbuf = 0;
 
     size = strlen( fmt ) + strlen( arg );
     if ( size > maxbuf )
@@ -3068,8 +3068,8 @@ static char*
 mm_build_env(char *fmt, mm_array_ptr<char> mm_arg) {
     char* cp;
     size_t size;
-    static _multiple mm_array_ptr<char> buf = NULL;
-    static _multiple size_t maxbuf = 0;
+    static _checkable mm_array_ptr<char> buf = NULL;
+    static _checkable size_t maxbuf = 0;
 
     char *arg = _getptr_mm_array<char>(mm_arg);
 
@@ -3330,8 +3330,8 @@ cgi_interpose_output( mm_ptr<httpd_conn> hc, int rfd )
     int r;
     char buf[1024];
     size_t headers_len;
-    _multiple size_t headers_size;
-    _multiple mm_array_ptr<char> headers = NULL;
+    _checkable size_t headers_size;
+    _checkable mm_array_ptr<char> headers = NULL;
     char* br;
     int status;
     char* title;
@@ -3691,17 +3691,17 @@ cgi( mm_ptr<httpd_conn> hc )
 static int
 really_start_request( mm_ptr<httpd_conn> hc, struct timeval* nowP )
     {
-    static _multiple mm_array_ptr<char> indexname = NULL;
-    static _multiple size_t maxindexname = 0;
+    static _checkable mm_array_ptr<char> indexname = NULL;
+    static _checkable size_t maxindexname = 0;
     static const char* index_names[] = { INDEX_NAMES };
     int i;
 #ifdef AUTH_FILE
-    static _multiple mm_array_ptr<char> dirname = NULL;
-    static _multiple size_t maxdirname = 0;
+    static _checkable mm_array_ptr<char> dirname = NULL;
+    static _checkable size_t maxdirname = 0;
 #endif /* AUTH_FILE */
     size_t expnlen, indxlen;
     char* cp;
-    _multiple mm_array_ptr<char> pi = NULL;
+    _checkable mm_array_ptr<char> pi = NULL;
 
     expnlen = strlen(_getptr_mm_array<char>(hc->expnfilename));
 
@@ -4111,8 +4111,8 @@ really_check_referrer( mm_ptr<httpd_conn> hc )
     char* cp1;
     char* cp2;
     char* cp3;
-    static _multiple mm_array_ptr<char> refhost = NULL;
-    static _multiple size_t refhost_size = 0;
+    static _checkable mm_array_ptr<char> refhost = NULL;
+    static _checkable size_t refhost_size = 0;
     char *lp;
 
     hs = hc->hs;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ PRINT_PASSES = -mllvm -opt-bisect-limit=-1
 #
 CC = $(LLVM_DIR)/clang $(CFLAGS)
 
-SRC = basic.c assign.c dereference.c func.c cast.c array.c addressof.c multiple.c
+SRC = basic.c assign.c dereference.c func.c cast.c array.c addressof.c checkable.c
 LIB = $(CHECKEDC_MISC)/lib-safemm.c
 OBJ = $(SRC:%.c=%.o)
 ASM = $(SRC:%.c=%.s)
@@ -84,8 +84,8 @@ array: array.c
 addrof: addressof.c
 	$(CC) $(LDFLAGS) $^ -o addressof
 
-mul: multiple.c
-	$(CC) $(LDFLAGS) $^ -o multiple
+chk: checkable.c
+	$(CC) $(LDFLAGS) $^ -o checkable
 
 opt: opt.c
 	$(CC) -S -O1 -emit-llvm $^

--- a/tests/checkable.c
+++ b/tests/checkable.c
@@ -1,5 +1,5 @@
 /**
- * Tests of the _multiple qualifier
+ * Tests of the _checkable qualifier
  * */
 
 #include "debug.h"
@@ -23,30 +23,30 @@ typedef struct {
     Obj *op;
 } NewNode;
 
-_multiple int gi = 30;
-_multiple int gi1;
-_multiple static int sgi = 40;
-_multiple static int sgi1;
+_checkable int gi = 30;
+_checkable int gi1;
+_checkable static int sgi = 40;
+_checkable static int sgi1;
 
-_multiple NewNode GNN;
-_multiple static NewNode SGNN;
+_checkable NewNode GNN;
+_checkable static NewNode SGNN;
 
 /*
- * Testing _multiple local and static local variables.
+ * Testing _checkable local and static local variables.
  * */
 void f0() {
-    print_start("_multiple local variables");
+    print_start("_checkable local variables");
     signal(SIGILL, ill_handler);
     if (setjmp(resume_context) == 1) goto resume;
 
-    _multiple int i = 10;
+    _checkable int i = 10;
     mm_ptr<int> p = &i;
     if (*p != 10) {
         print_error("multiple.c::f0():: getting the address of a stack integer");
     }
 
     // Test getting the address of a field of a local struct.
-    _multiple NewNode NN;
+    _checkable NewNode NN;
     mm_ptr<long> pl = &NN.l;
     mm_ptr<Obj> po = &NN.o;
     mm_ptr<int> pi = &NN.arr[3].i;
@@ -57,14 +57,14 @@ void f0() {
     }
 
     // Test getting the address of a static local integer.
-    _multiple static int si = 30;
+    _checkable static int si = 30;
     p = &si;
     if (*p != 30) {
         print_error("multiple.c::f0():: getting the address of a static local integer");
     }
 
     // Test getting the address of a field of a static local variable.
-    _multiple static NewNode SNN;
+    _checkable static NewNode SNN;
     pl = &SNN.l;
     po = &SNN.o;
     pi = &SNN.arr[3].i;
@@ -74,7 +74,7 @@ void f0() {
                     "static local struct");
     }
 
-    print_end("_multiple local variables");
+    print_end("_checkable local variables");
     return;
 
 resume:
@@ -82,10 +82,10 @@ resume:
 }
 
 /**
- * Test _multiple global variables
+ * Test _checkable global variables
  * */
 void f1() {
-    print_start("_multiple global variables");
+    print_start("_checkable global variables");
     signal(SIGILL, ill_handler);
     if (setjmp(resume_context) == 1) goto resume;
 
@@ -124,7 +124,7 @@ void f1() {
         print_error("multiple.c::f0():: getting the address of a field of a "
                     "static global struct");
     }
-    print_end("_multiple global variables");
+    print_end("_checkable global variables");
     return;
 
 resume:

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -13,6 +13,7 @@ SRC=(
     "cast"
     "array"
     "addressof"
+    "checkable"
 )
 
 #


### PR DESCRIPTION
Now we have implemented `mm_array_ptr` using the 2-field structure `{T *p, uint64_t key_offset}` same as `mm_ptr`. 

- Updated the runtime library.
- Also updated the keyword `_multiple` to `_checkable`.